### PR TITLE
Weekly events are not returned on the last day of a valid period.

### DIFF
--- a/src/main/java/org/devmaster/elasticsearch/index/mapper/Recurring.java
+++ b/src/main/java/org/devmaster/elasticsearch/index/mapper/Recurring.java
@@ -171,7 +171,7 @@ public final class Recurring {
             LocalDateIterator it = LocalDateIteratorFactory.createLocalDateIterator(rrule, new LocalDate(startDate), false);
             it.advanceTo(lookingAtInterval.getStart().toLocalDate());
             if (it.hasNext()) {
-                for (LocalDate current = it.next(); it.hasNext() && !current.isAfter(lookingAtInterval.getEnd().toLocalDate()); current = it.next()) {
+                for (LocalDate current = it.next(); !current.isAfter(lookingAtInterval.getEnd().toLocalDate()); current = it.next()) {
                     if (lookingAtInterval.abuts(current.toInterval()) || lookingAtInterval.contains(current.toInterval())) {
                         return true;
                     }

--- a/src/test/java/org/devmaster/elasticsearch/index/mapper/RecurringTest.java
+++ b/src/test/java/org/devmaster/elasticsearch/index/mapper/RecurringTest.java
@@ -149,6 +149,19 @@ public class RecurringTest {
     }
 
     @Test
+    public void test_hasAnyOccurrenceBetween_weekly() throws Exception {
+        Recurring recurring = new Recurring("2018-05-02", "2018-06-07", "RRULE:FREQ=WEEKLY;BYDAY=TU;UNTIL=20180607T000000Z;WKST=SU");
+
+        assertTrue(recurring.hasAnyOccurrenceBetween("2018-05-08", "2018-05-08"));
+        assertTrue(recurring.hasAnyOccurrenceBetween("2018-05-15", "2018-05-15"));
+        assertTrue(recurring.hasAnyOccurrenceBetween("2018-05-22", "2018-05-22"));
+        assertTrue(recurring.hasAnyOccurrenceBetween("2018-05-29", "2018-05-29"));
+        assertTrue(recurring.hasAnyOccurrenceBetween("2018-06-05", "2018-06-05"));
+        assertFalse(recurring.hasAnyOccurrenceBetween("2018-06-06", "2018-06-06"));
+
+    }
+
+    @Test
     public void test_occurBetween_withSameDay() throws Exception {
         Recurring recurring = new Recurring("2016-11-10", "2016-11-10", null);
 


### PR DESCRIPTION
Scenario: weekly event, that happens every Tuesday, starts on May 2nd, 2018 and ends on May 17th, 2018.
Searching for occurrences on May 15th (valid date), doesn't return any event.

This pull request fixes this problem.